### PR TITLE
修复预热时在非协程上coroutine.yield()导致程序卡死使得核反应堆失控的问题

### DIFF
--- a/action.lua
+++ b/action.lua
@@ -115,7 +115,7 @@ local function preheatRc(rc)
     local rcComponent = component.proxy(rc.reactorChamberAddr)
     if rcComponent.getHeat() >= rc.thresholdHeat then return true end
     insert(rc.transforAddr, rc.tempSide, 1, rc.reactorChamberSide, rc.preheatItem, -1)
-    startReactorChamber(rc)
+    startReactorChamber(rc, false)
     repeat
         local heat = rcComponent.getHeat()
         if not database.getGlobalRedstone() then


### PR DESCRIPTION
这样就修复了吧。。。应该