### PR TITLE
fix: 材料装载失败：/home/action.lua:17: attempt to index a nil value (local 'rc')

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -13,8 +13,10 @@ return {
                     slot = { 3, 6, 9, 10, 15, 22, 26, 29, 33, 40, 45, 46, 49, 52 }
                 },
                 {
-                    name = "gregtech:gt.reactorUraniumQuad",
-                    changeName = "IC2:reactorUraniumQuaddepleted",
+                    -- name = "gregtech:gt.reactorUraniumQuad",
+                    name = "gregtech:gt.rodUranium4",
+                    -- changeName = "IC2:reactorUraniumQuaddepleted",
+                    changeName = "gregtech:gt.depletedRodUranium4",  
                     dmg = -1,
                     count = 40,
                     slot = {

--- a/database.lua
+++ b/database.lua
@@ -83,7 +83,7 @@ local function scanAdaptor()
     print("读取到" .. #reactorChamberList .. "个核电配置")
     
     -- 清理旧数据
-    reactorChambers = {}
+    for k in pairs(reactorChambers) do reactorChambers[k] = nil end
     componentCache = {}
     
     for i = 1, #reactorChamberList do


### PR DESCRIPTION
 bug位于 database.lua 文件中。当 scanAdaptor 函数运行时，它会创建一个新的、局部的 reactorChambers 表来存储扫描到的反堆配置。
然而，其他脚本（如action.lua）仍然引用着模块加载时创建的那个旧的、空的 reactorChambers 表。
因此，当 action.lua 尝试从 database.reactorChambers 中获取数据时，它访问的是一个空表，导致 rc 变量为 nil，从而引发了你看到的崩溃。

解决方案：
修改 database.lua 中的 scanAdaptor 函数，将 reactorChambers = {} 这一行替换为能够就地清空 reactorChambers表的代码，
而不是创建一个新表。这样可以确保所有脚本都引用同一个、并且被正确填充了数据的表。